### PR TITLE
Fix model filtering based on range

### DIFF
--- a/smartwatts/formula.py
+++ b/smartwatts/formula.py
@@ -108,7 +108,7 @@ class PowerModel:
         model: Regression = Regression(fit_intercept=fit_intercept, positive=True).fit(self.history.X, self.history.y)
 
         # Discard the new model when the intercept is not in specified range
-        if not (min_intercept < model.intercept_ < max_intercept):
+        if not (min_intercept <= model.intercept_ < max_intercept):
             return
 
         self.model = model


### PR DESCRIPTION
We currently discard all models that are not in the range
  min_intercept < model.intercept_ < max_intercept

However, when we have more than min_samples_required but less than
history_window_size points in history, we force the intercept to 0
(fit_intercept=False).

This means that we actually discard all these models, until the history
contains history_window_size points.

This fix simply allows having a model with a 0 intercept by using <= instead of <.