### PR TITLE
Fix cli argument name

### DIFF
--- a/smartwatts/__main__.py
+++ b/smartwatts/__main__.py
@@ -82,7 +82,7 @@ def setup_cpu_formula_actor(fconf, route_table, report_filter, cpu_topology, pus
     """
     def cpu_formula_factory(name: str, _):
         scope = SmartWattsFormulaScope.CPU
-        config = SmartWattsFormulaConfig(scope, fconf['sensor-reports-frequency'], fconf['cpu-rapl-ref-event'], fconf['cpu-error-threshold'], cpu_topology, fconf['learn-min-samples-required'], fconf['learn-min-samples-required'])
+        config = SmartWattsFormulaConfig(scope, fconf['sensor-reports-frequency'], fconf['cpu-rapl-ref-event'], fconf['cpu-error-threshold'], cpu_topology, fconf['learn-min-samples-required'], fconf['learn-history-window-size'])
         return SmartWattsFormulaActor(name, pushers, config)
 
     cpu_dispatcher = DispatcherActor('cpu_dispatcher', cpu_formula_factory, route_table)


### PR DESCRIPTION
When creating the `SmartWattsFormulaConfig`, the cli argument
`learn-min-samples-required` is used twice. `learn-history-window-size`
should be used instead for `history_window_size`.