### PR TITLE
Cloudjoule - support for Kubernetes 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ setup_requires =
     pytest-runner >=3.9.2
 install_requires =
     powerapi [mongodb, influxdb, opentsdb, prometheus, influxdb_client] >= 1.1.0
-
+    kubernetes
     scikit-learn
 tests_require =
     pytest >=3.9.2

--- a/smartwatts/cloudjoule_exporter.py
+++ b/smartwatts/cloudjoule_exporter.py
@@ -1,0 +1,359 @@
+# CloudJoule — for powerAPI
+#
+# Copyright (c) 2022 Orange - All right reserved
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from asyncio.log import logger
+import logging
+from typing import List, Type, Dict
+
+from prometheus_client import Gauge, Counter
+
+from powerapi.report import Report
+from powerapi.database.prometheus_db import BasePrometheusDB
+
+"""
+Prometheus Exporter for cloudjoule (powerapi inside k8s)
+
+
+"""
+
+class CloudJoulePrometheusDB(BasePrometheusDB):
+
+    """
+    Database that expose received data as metric in order to be scrapped by a prometheus instance
+    Can only be used with a pusher actor.
+
+    The exporter exposes one gauge and one counter metric
+    * for rapl energy (total cpu energy usage)
+    * for the global energy usage estimated by powerAPI
+    * for the estimated energy usage of each pod 
+    
+    the pod metrics contain:
+    * the pod name : `pod_name`
+    * the pod namespace : `pod_name_space`
+    * the name of the sensor
+    * the k8s target (something like `/kubepods/besteffort/pod<uid>/<uid>`)
+    * a subset of the k8s labels of the pod 
+      * specified using the `tags` argument in the constructor
+      * their value is empty for pods that do not have these labels
+      * the name id prepended with `label_` . E.g. for a pod holding the k8s label `app=application-2`, the 
+        prometheus metric will have a tag `label_app="application-2"`
+
+    Example of the pod energy counter : 
+    ```
+    cloudjoule_pod_joule_total{label_app="application-2",label_env="",label_k8s_app="",label_service="",pod_name="application-2-5ff95cdbf5-h9xzz",pod_namespace="application-2",sensor="sensor_test",target="/kubepods/besteffort/pod9d7592ea-f1da-4ead-982f-4cd30bb0e1b5/bec1f163e3e1c5ecb019c55034c169df59cd1c489cf276dc4d22e6ab5f1c0bf9"} 0.0
+    ```
+    """
+
+    def __init__(
+        self,
+        report_type: Type[Report],
+        port: int,
+        address: str,
+        metric_name: str,
+        metric_description: str,
+        tags: List[str],
+    ):
+        """
+
+        Note: here tags will in most cases be the names of k8s labels.
+
+        :param address:             address that expose the metric
+        :param port:
+        :param metric_name:
+        :param metric_description:  short sentence that describe the metric
+        :param tags: metadata used to tag metric
+        """
+        tags += ["pod_name", "pod_namespace", "socket"]
+        self.labels_conversion = fix_k8s_labels_names(tags)
+        tags = list(self.labels_conversion.values())
+        BasePrometheusDB.__init__(
+            self, report_type, port, address, metric_name, metric_description, tags
+        )
+
+        self.labels_conversion = fix_k8s_labels_names(tags)
+
+        # check for inactive measure every x seconds
+        self.CLEANUP_PERIOD = 10
+        # if a measure had not update for the last INACTIVE_TIMEOUT seconds, remove it
+        self.INACTIVE_TIMEOUT = 60
+        # timestamp of the last inactive measures cleanup
+        self.cleanup_ts = 0
+
+        self.rapl_counter = None
+        self.rapl_gauge = None
+
+        self.global_gauge = None
+        self.global_counter = None
+
+        self.pod_counter = None
+        self.pod_gauge = None
+
+        # a dict  str -> dict like: { "tag1.tag2....tagn": value}
+        # where value is a array of tag, needed to remove the measure from the exporter:
+        # [measure["tags"][label] for label in measure["tags"]]
+        self.exposed_measure = {}
+
+        # a map measure_key -> ts
+        # with for each measure the last ts at which we received an update
+        self.measure_last_ts = {}
+
+    def __iter__(self):
+        raise NotImplementedError()
+
+    def _init_metrics(self):
+        logging.debug(f"init metrics {self.tags}")
+        self.rapl_gauge = Gauge(
+            f"{self.metric_name}_rapl_power",
+            "Gauge for total CPU energy",
+            labelnames=["sensor", "socket"],
+        )
+        self.rapl_counter = Counter(
+            f"{self.metric_name}_rapl_joule",
+            "Counter for total CPU energy",
+            labelnames=["sensor", "socket"],
+        )
+
+        self.global_gauge = Gauge(
+            f"{self.metric_name}_global_power",
+            "Gauge for global estimated energy",
+            labelnames=["sensor", "socket"],
+        )
+        self.global_counter = Counter(
+            f"{self.metric_name}_joule",
+            "Counter for global estimated energy",
+            labelnames=["sensor", "socket"],
+        )
+
+        self.pod_gauge = Gauge(
+            f"{self.metric_name}_pod_power",
+            self.metric_description,
+            labelnames=["sensor", "target"] + self.tags,
+        )
+        self.pod_counter = Counter(
+            f"{self.metric_name}_pod_joule",
+            self.metric_description,
+            labelnames=["sensor", "target"] + self.tags,
+        )
+
+    def _expose_data(self, key, measure):
+
+        print(f" _expose_data {measure}")
+
+        logging.debug(f" _expose_data {measure}")
+
+        # select the right gauge, counter and labels depending on the measure
+        target = measure["tags"]["target"]
+        if target == "rapl":
+            gauge = self.rapl_gauge
+            counter = self.rapl_counter
+            labels = {"sensor": measure["tags"]["sensor"], "socket" : measure["tags"]["socket"]}
+        elif target == "global":
+            gauge = self.global_gauge
+            counter = self.global_counter
+            labels = {"sensor": measure["tags"]["sensor"], "socket" : measure["tags"]["socket"]}
+        else:
+            gauge = self.pod_gauge
+            counter = self.pod_counter
+            labels = self._fill_tags(measure["tags"])
+
+        # Update gauge and counter
+        try: 
+            gauge.labels(**labels).set(measure["value"])
+            if key in self.measure_last_ts:
+                # For counter: take duration since last update into account !
+                duration = measure["time"] - self.measure_last_ts[key]
+                counter.labels(**labels).inc(measure["value"] * duration)
+                self.measure_last_ts[key] = measure["time"]
+            else:
+                # first report for this measure, we cannot yet compute a consumption
+                self.measure_last_ts[key] = measure["time"]
+        except ValueError as ve:
+            logger.error(f"Cannot publish measure for target {target} : {ve} - {labels} - {measure}")
+            print(f"Cannot publish measure for target {target} : {ve} - {labels} - {measure}")
+
+    def save(self, report: Report):
+        """
+        Override from BaseDB
+
+        :param report: Report to save
+        """
+        logging.debug(
+            f"CLOUDJOULE saving report {report} metadata : -{report.metadata}-"
+        )
+
+        self._fix_label_names(report)
+
+        key, measure = self._report_to_measure_and_key(report)
+        self._expose_data(key, measure)
+        # store exposed measure with associated labels to be able
+        # to remove measure that did not receive any update since INACTIVE_TIMEOUT
+        self.exposed_measure[key] = list(measure["tags"].values())
+
+        current_ts = measure["time"]
+        if current_ts - self.cleanup_ts > self.CLEANUP_PERIOD:
+            self._cleanup_measures(current_ts)
+
+    def _cleanup_measures(self, current_ts):
+        """
+        Remove any measures that had no update during the last
+        `INACTIVE_TIMEOUT` seconds
+        """
+        for key, ts in list(self.measure_last_ts.items()):
+            if current_ts - ts > self.INACTIVE_TIMEOUT:
+                logging.debug(
+                    f"CLOUDJOULE - REMOVE measure inactive for more than {self.INACTIVE_TIMEOUT}s {ts} {current_ts}  {key} "
+                )
+                args = self.exposed_measure[key]
+                try: 
+                    self.pod_counter.remove(*args)
+                    self.pod_gauge.remove(*args)
+                    self.measure_last_ts.pop(key)
+                    self.exposed_measure.pop(key)
+                except: 
+                    pass
+            else:
+                logging.debug(
+                    f"CLOUDJOULE - KEEP measure active < {self.INACTIVE_TIMEOUT}s {ts} {current_ts}  {key} "
+                )
+
+        self.cleanup_ts = current_ts
+
+    def save_many(self, reports: List[Report]):
+        """
+        Save a batch of data
+
+        :param reports: Batch of data.
+        """
+        for report in reports:
+            self.save(report)
+
+    def _fix_label_names(self, report: Report):
+
+        # replace k8s labels names in the report's metadata with their fixed version
+        # for prometheus
+        for original_name in list(report.metadata):
+            if original_name in self.labels_conversion:
+                report.metadata[
+                    self.labels_conversion[original_name]
+                ] = report.metadata.pop(original_name)
+
+    def _fill_tags(self, tags: Dict[str, str]):
+        # Prometheus defines tags at the metrics creation time, and they then
+        # become mandatory. As we don't want to create a new metrics for each
+        # set of tags, we simply add empty value for all missing tags:
+        all_tags = tags.copy()
+        for k in self.tags:
+            if k not in all_tags:
+                all_tags[k] = ""
+        return all_tags
+
+    def _report_to_measure_and_key(self, report):
+        # `report_to_prom` build a dict
+        # { 'time': <timestamp_int>,
+        #   'value': <power>,
+        #   'tags': {
+        #     'sensor' : <sensor>, 'target' : <target>, 'label_xx' : 'value' ...
+        #   }
+        # }
+        value = report_to_prom(report, self.tags)
+
+        key = "".join([str(value["tags"][tag]) for tag in value["tags"]])
+        return key, value
+
+
+def report_to_prom(report, tags_keep):
+    tags = {"sensor": report.sensor, "target": report.target}
+    for metadata_name in tags_keep:
+        if metadata_name not in report.metadata:
+            # raise BadInputData('no tag ' + metadata_name + ' in power report', self)
+            tags[metadata_name] = ""
+        else:
+            tags[metadata_name] = report.metadata[metadata_name]
+
+    return {
+        "tags": tags,
+        "time": int(report.timestamp.timestamp()),
+        "value": report.power,
+    }
+
+
+def fix_k8s_labels_names(label_names: List[str]) -> Dict[str, str]:
+    """
+    Fix k8s label names, returns a dict { original_name : fixed_name}.
+
+    When using k8s label names as label names for prometheus, we run into issues
+    as they have different rules regarding allowed characters.
+
+    Prometheus:
+    * must match regexp `[a-zA-Z_:][a-zA-Z0-9_:]*`
+    * https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+
+    Kubernetes:
+    * "The name segment is required and must be 63 characters or less,
+       beginning and ending with an alphanumeric character ([a-z0-9A-Z])
+       with dashes (-), underscores (_), dots (.), and alphanumerics between. [...]"
+    * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+
+    To avoid this issue we convert characters not allowed in prometheus
+    to underscore. We also prepend "label_" in front of the label name.
+
+    With these rules, we can into conflicts when different k8s label names are
+    converted to the same prometheus label name. In that case we flag
+    these conflicts by adding `_conflict{1}` to the name. This matches
+    what is done by kube-state-metrics:
+
+    https://github.com/kubernetes/kube-state-metrics#conflict-resolution-in-label-names
+
+    Note however that we don't add a `"_label"` prefix to the labels
+    names here.
+
+    """
+    fixed_names = {}
+    for label_name in label_names:
+        fixed_names[label_name] = fix_k8s_labels_name(label_name)
+
+    # detect and flag conflicts
+    names_list = list(fixed_names.values())
+    conflicts = [name for name in names_list if names_list.count(name) > 1]
+    for conflict in set(conflicts):
+        for i, (k, v) in enumerate(list(fixed_names.items())):
+            if v == conflict:
+                fixed_names[k] = v + f"_conflict{i+1}"
+
+    return fixed_names
+
+
+def fix_k8s_labels_name(label_name: str) -> str:
+    """
+    Fix a single k8s label name, see fix_k8s_labels_names for details.
+    """
+    label_name = label_name.replace("-", "_")
+    label_name = label_name.replace(".", "_")
+    label_name = label_name.replace("/", "_")
+    return label_name

--- a/smartwatts/configuration.py
+++ b/smartwatts/configuration.py
@@ -1,0 +1,185 @@
+# CloudJoule — for powerAPI
+#
+# Copyright (c) 2022 Orange - All right reserved
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import logging
+import os
+
+from powerapi.cli import ConfigValidator
+
+"""
+This module supports configuring some key parameter using environment variables.
+This is useful, and recommended (cf. twelve-factor app), when running in a environment where changing 
+the configuration file across deployments (e.g. k8s in our case).
+
+At the moment, only a subset of configuration parameters are supported.
+It's currently quite a hack and should probably be merged with the existing 
+configuration mechanism, which currently supports file and cli arguments.
+"""
+
+logger = logging.getLogger("node-power-exporter.configuration")
+
+# connection mode for K8S API, manual, local or cluster
+K8SAPI_MODE="cluster"
+
+LOG_LEVEL = "INFO"
+
+# The frequency with which measurements are made (in milliseconds)
+REPORT_FREQ = 1000
+
+# Error threshold for the power models (in Watt) - can be set for CPU and DRAM:
+ERROR_THRESHOLD = 2
+
+# Minimum amount of samples required before trying to learn a power model:
+MIN_SAMPLES_REQUIRED = 10
+
+# Size of the history window used to keep samples to learn from:
+HISTORY_WINDOW_SIZE = 60
+
+# Frequencies configuration
+MIN_FREQ = None
+MAX_FREQ = None
+BASE_FREQ = None
+
+# Number of sockets
+SOCKET_COUNT = None
+
+# TDP
+CPU_TDP = 125
+
+BASE_CLOCK = 100
+
+EXPORTER_LABELS=["app","service","env"]
+
+EXPORTER_PORT=8124
+
+def load_config_from_env():
+    global LOG_LEVEL, REPORT_FREQ, ERROR_THRESHOLD,\
+        MIN_SAMPLES_REQUIRED, HISTORY_WINDOW_SIZE, \
+        MIN_FREQ, MAX_FREQ, BASE_FREQ, SOCKET_COUNT, CPU_TDP, \
+        K8SAPI_MODE, EXPORTER_LABELS, EXPORTER_PORT
+
+    # Get the configuration from environment variables:
+    try:
+        K8SAPI_MODE = safe_get_env("K8SAPI_MODE", str)
+        LOG_LEVEL = safe_get_env("LOG_LEVEL", str)
+        REPORT_FREQ = safe_get_env("REPORT_FREQ", int)
+        ERROR_THRESHOLD = safe_get_env("ERROR_THRESHOLD", float)
+        MIN_SAMPLES_REQUIRED = safe_get_env("MIN_SAMPLES_REQUIRED", int)
+        HISTORY_WINDOW_SIZE = safe_get_env("HISTORY_WINDOW_SIZE", int)
+        CPU_TDP = safe_get_env("CPU_TDP", int)
+        EXPORTER_PORT = safe_get_env("EXPORTER_PORT", int)
+        EXPORTER_LABELS = safe_get_env("EXPORTER_LABELS", to_list)
+        EXPORTER_LABELS = [f"label_{label}" for label in EXPORTER_LABELS]
+
+        # Frequencies configuration
+        MIN_FREQ = int(float(os.environ["MIN_FREQ"]) / 100)
+        MAX_FREQ = int(float(os.environ["MAX_FREQ"]) / 100)
+        BASE_FREQ = int(float(os.environ["BASE_FREQ"]) / 100)
+
+        # Number of sockets
+        SOCKET_COUNT = int(os.environ["SOCKET_COUNT"])
+
+    except Exception as e:
+        logger.error(f"Invalid configuration for ENV : {e}")
+        raise
+
+
+def to_list(s):
+    return [p.strip() for p in  s.split(",")]
+
+
+def safe_get_env(ENV_NAME, conversion):
+    try:
+        return conversion(os.environ[ENV_NAME])
+    except KeyError:
+        pass
+        return globals()[ENV_NAME]
+
+
+def get_smartwatt_config_map():
+    """
+    Returns the configuration as a map with the same keys
+    than used and expected by smartwatt.
+    """
+    if SOCKET_COUNT is None:
+        raise RuntimeError("Load config must have been called before !")
+    conf = {
+        # Constant conf item in our case
+        "stream": True,
+        "actor_system": "simpleSystemBase",
+        "disable-cpu-formula": False,
+        "disable-dram-formula": True,
+        "cpu-rapl-ref-event": "RAPL_ENERGY_PKG",
+        "dram-rapl-ref-event": "RAPL_ENERGY_DRAM",
+        "verbose": LOG_LEVEL == "DEBUG",  
+        # TODO: not sure what that means
+        "real-time-mode": False,
+        # Items from env variables
+        "cpu-tdp": CPU_TDP,
+        "cpu-base-clock": BASE_CLOCK,
+        "sensor-report-sampling-interval": REPORT_FREQ,
+        "learn-min-samples-required": MIN_SAMPLES_REQUIRED,
+        "learn-history-window-size": HISTORY_WINDOW_SIZE,
+        "cpu-error-threshold": ERROR_THRESHOLD,
+        # Model use frequency in 100MHz
+        "cpu-frequency-base": BASE_FREQ,
+        "cpu-frequency-min": MIN_FREQ,
+        "cpu-frequency-max": MAX_FREQ,
+        "k8sapi_mode": K8SAPI_MODE
+    }
+
+    # Output hardcoded to our custom prometheus exporter
+    # TODO : move this to the external configuration file ?
+    conf["output"] = {
+        "pusher_power": {
+            "type": "cloudjoule_prom",
+            "uri": "127.0.0.1",
+            "port": EXPORTER_PORT,
+            "metric_name": "cloudjoule",
+            "metric_description": "cloudjoule energy metric",
+            "model": "PowerReport",
+            "labels" : EXPORTER_LABELS
+        }
+    }
+
+    # Input hardcoded to a locally running sensor outputting
+    # to a socket port 12000
+    conf["input"] = {
+        "socket_puller": {
+            "model": "HWPCReport",
+            "type": "socket",
+            "uri": "127.0.0.1",
+            "port": 12000,
+        }
+    }
+
+    # make sure the conf is valid for power api
+    ConfigValidator.validate(conf)
+    return conf

--- a/smartwatts/configuration.py
+++ b/smartwatts/configuration.py
@@ -79,6 +79,37 @@ EXPORTER_LABELS=["app","service","env"]
 
 EXPORTER_PORT=8124
 
+def configure_log_level():
+    """
+    Configure log level according to the value of `LOG_LEVEL`.
+
+    If `load_config_from_env()` has been called previously,
+    the value is read from the environment variable. Otherwise it
+    defaults to "INFO".
+    """
+    try:
+        log_level = {
+            "INFO": logging.INFO,
+            "DEBUG": logging.DEBUG,
+            "ERROR": logging.ERROR,
+            "WARNING": logging.WARNING,
+        }[LOG_LEVEL]
+        logging.basicConfig(
+            format="%(asctime)s#%(levelname)s:%(message)s", level=log_level
+        )
+    except Exception:
+        logger.error(
+            "Invalid log level, use DEBUG, INFO, WARNING or ERROR : %s",
+            LOG_LEVEL
+        )
+        raise
+    print(f"Log level {LOG_LEVEL}")
+    logging.debug("Debug Message")
+    logging.info("Info Message")
+    logging.warning("Warning Message")
+    logging.error("Error Message")
+
+
 def load_config_from_env():
     global LOG_LEVEL, REPORT_FREQ, ERROR_THRESHOLD,\
         MIN_SAMPLES_REQUIRED, HISTORY_WINDOW_SIZE, \

--- a/smartwatts/k8sapi.py
+++ b/smartwatts/k8sapi.py
@@ -1,0 +1,492 @@
+# CloudJoule — for powerAPI
+#
+# Copyright (c) 2022 Orange - All right reserved
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from datetime import timedelta
+import logging
+from typing import Dict, List, Tuple
+
+from kubernetes import client, config, watch
+from kubernetes.client.configuration import Configuration
+from kubernetes.client.rest import ApiException
+
+from powerapi.actor import Actor
+from powerapi.message import (
+    EndMessage,
+    Message,
+    StartMessage,
+)
+from powerapi.report import HWPCReport
+
+from thespian.actors import (
+    ActorAddress,
+    ActorExitRequest,
+    ChildActorExited,
+    WakeupMessage,
+)
+
+"""
+This module provides two k8s specific actors
+* `K8sMdtModifierActor`, which add k8s metadata to reports 
+  and forward them to another actor.
+* `K8sMonitorAgent`, which monitors the k8s API and sends 
+  messages when pod are created, removed or modified.
+  
+"""
+
+v1_api = None
+
+LOCAL_CONFIG_MODE = "local"
+MANUAL_CONFIG_MODE = "manual"
+CLUSTER_CONFIG_MODE = "cluster"
+
+logger = logging.getLogger("node-power-exporter.k8sapi")
+
+
+def local_config():
+    # local kubectl
+    config.load_kube_config()
+
+
+def manual_config():
+    # Manual config
+    configuration = client.Configuration()
+    # Configure API key authorization: BearerToken
+    configuration.api_key["authorization"] = "YOUR_API_KEY"
+    # Defining host is optional and default to http://localhost
+    configuration.host = "http://localhost"
+    Configuration.set_default(configuration)
+
+
+def cluster_config():
+    config.load_incluster_config()
+
+
+def load_k8s_client_config(mode=None):
+    """
+    Load K8S client configuration according to the `mode`.
+    If no mode is given `LOCAL_CONFIG_MODE` is used.
+
+    params:
+        mode : one of `LOCAL_CONFIG_MODE`, `MANUAL_CONFIG_MODE`
+               or `CLUSTER_CONFIG_MODE`
+
+    """
+    logger.debug("Loading k8s api conf mode %s " , mode)
+    {
+        LOCAL_CONFIG_MODE: local_config,
+        MANUAL_CONFIG_MODE: manual_config,
+        CLUSTER_CONFIG_MODE: cluster_config,
+    }.get(mode, local_config)()
+
+
+def get_core_v1_api(mode=None):
+    """
+    Returns an handle to the k8s API.
+    """
+    global v1_api
+    if v1_api is None:
+        load_k8s_client_config(mode)
+        v1_api = client.CoreV1Api()
+        print(f"Core v1 api access : {v1_api}")
+    return v1_api
+
+
+class K8sMdtModifierStartMessage(StartMessage):
+    """Start Message for K8sMdtModifierActor"""
+    def __init__(self, sender_name: str, name: str, forward_actor: str, k8sapi_mode: str):
+        """
+        :param forward_actor address of the agent the K8sMdtModifierActor will
+               forward modified messages to.
+        """
+        StartMessage.__init__(self, sender_name, name)
+        self.forward_actor = forward_actor
+        self.k8sapi_mode = k8sapi_mode
+
+    def __str__(self):
+        return "K8sMdtModifierStartMessage"
+
+
+class K8sPodUpdateMessage(Message):
+    """Message sent by the K8sMonitorAgent everytime it detects a change
+       on pod in K8S.
+    """
+    def __init__(
+        self,
+        sender_name: str,
+        event: str,
+        namespace: str,
+        pod: str,
+        containers_id: List[str] = None,
+        labels: Dict[str, str] = None,
+    ):
+        """
+
+        :param datetime timestamp: Timestamp
+        :param str sensor: Sensor name.
+        :param str target: Target name.
+        """
+        Message.__init__(self, sender_name)
+        self.event = event
+        self.namespace = namespace
+        self.pod = pod
+        self.containers_id = containers_id if containers_id is not None else []
+        self.labels = labels if labels is not None else dict()
+
+    def __str__(self):
+        return f"K8sPodUpdateMessage {self.event} {self.namespace} {self.pod}"
+
+
+class K8sMdtModifierActor(Actor):
+    """
+    Add k8s metadata to reports and forward them to another actor.
+
+    Metadata is a dict on the report, if the target of the report
+    is a container that we can associate to a pod, we add:
+    * '"pod_name" : <name_of_the_pod>`
+    * '"pod_namespace" : <namespane_of_the_pod>`
+    * '"label_"<label_name> : <label_value>` for each label on the pod
+
+    If the target of the report cannot be associated to a pod
+    (e.g. `rapl` or `all` targets) no metadata is added.
+
+    To avoid querying k8s API for each report, this actor maintains a cache
+    of k8s  pod meta-data information. The cache is kept up-to-date thanks
+    to messages from the `K8sMonitorAgent`.
+    """
+
+    def __init__(self):
+        Actor.__init__(self, K8sMdtModifierStartMessage)
+        self.log_debug("Init K8sMdtModifierActor")
+        self.forward_actor = None
+        self.mdt_cache = None
+        self.monitor_agent = None
+
+    def _initialization(self, start_message: StartMessage):
+        self.log_debug("Initializing K8s Modifier actor")
+        Actor._initialization(self, start_message)
+        self.log_debug("Initializing K8s Modifier actor")
+        self.mdt_cache = K8sMdtCache()
+
+        self.forward_actor = start_message.forward_actor
+        # Create monitor agent:
+        self.log_debug("Creating monitor agent")
+        self.monitor_agent = self.createActor(K8sMonitorAgent)
+        self.log_debug("Sending start to monitor agent")
+        self.send(
+            self.monitor_agent,
+            K8sMonitorStartMessage(
+                self.name,
+                "k8s_monitor_agent",
+                self.myAddress,
+                start_message.k8sapi_mode),
+        )
+
+    def receiveMsg_EndMessage(self, message: EndMessage, _: ActorAddress):
+        """
+        when receiving a EndMessage kill itself
+        """
+        self.log_debug("K8sMdtModifierActor received message " + str(message))
+
+        self.send(self.forward_actor, EndMessage(self.name))
+        self.send(self.myAddress, ActorExitRequest())
+
+    def receiveMsg_K8sPodUpdateMessage(self, message, _: ActorAddress):
+
+        self.log_debug(f"received K8sPodUpdateMessage message {message}")
+        self.mdt_cache.update_cache(message)
+
+    def receiveMsg_ChildActorExited(
+            self,
+            _msg: ChildActorExited,
+            _: ActorAddress):
+        self.log_error("Error Child agent K8S monitor failed")
+
+    def receiveMsg_OKMessage(self, message, _: ActorAddress):
+        # received when the Monitor agent has been started successfully
+        pass
+
+    def receiveMsg_HWPCReport(self, message: HWPCReport, _):
+
+        # Add pod name, namespace and labels to the report
+        c_id = cleanup_container_id(message.target)
+        ns, pod = self.mdt_cache.get_container_pod(c_id)
+        if ns is None or pod is None:
+            self.log_warning(
+                f"Container with no associated pod : {message.target}, {c_id}, {ns}, {pod}" 
+            )
+            # self.log_debug(f"MDT_CACHE DUMP : {self.mdt_cache.pod_containers} \n "
+            #                f" {self.mdt_cache.containers_pod} \n" 
+            #                f" {self.mdt_cache.pod_labels} ")
+        else:
+            message.metadata["pod_namespace"] = ns
+            message.metadata["pod_name"] = pod
+            self.log_debug(
+                f"K8sMdtModifierActor add mdt to report {c_id}, {ns}, {pod}"
+            )
+
+            labels = self.mdt_cache.get_pod_labels(ns, pod)
+            for label_key, label_value in labels.items():
+                message.metadata[f"label_{label_key}"] = label_value
+
+        self.send(self.forward_actor, message)
+
+
+class K8sMdtCache:
+    """
+    K8sMdtCache maintains a cache of pods' metadata
+    (namespace, labels and id of associated containers)
+    """
+    def __init__(self):
+        self.pod_labels = dict() # (ns, pod) => [labels]
+        self.containers_pod = dict() # container_id => (ns, pod)
+        self.pod_containers = dict() # (ns, pod) => [container_ids]
+
+    def update_cache(self, message: K8sPodUpdateMessage):
+        """
+        Update the local cache for pods.
+
+        Register this function as a callback for K8sMonitorAgent messages.
+        """
+        if message.event == "ADDED":
+            self.pod_labels[(message.namespace, message.pod)] = message.labels
+            self.pod_containers[
+                (message.namespace, message.pod)
+            ] = message.containers_id
+            for container_id in message.containers_id:
+                self.containers_pod[container_id] = \
+                    (message.namespace, message.pod)
+            # logger.debug(
+            #     "Pod added  %s %s - mdt: %s",
+            #     message.namespace, message.pod, message.containers_id
+            # )
+
+        elif message.event == "DELETED":
+            self.pod_labels.pop((message.namespace, message.pod), None)
+            for container_id in self.pod_containers.pop(
+                (message.namespace, message.pod), []
+            ):
+                self.containers_pod.pop(container_id, None)
+            # logger.debug("Pod removed %s %s", message.namespace, message.pod)
+
+        elif message.event == "MODIFIED":
+            self.pod_labels[(message.namespace, message.pod)] = message.labels
+            for prev_container_id in self.pod_containers.pop(
+                (message.namespace, message.pod), []
+            ):
+                self.containers_pod.pop(prev_container_id, None)
+            self.pod_containers[
+                (message.namespace, message.pod)
+            ] = message.containers_id
+            for container_id in message.containers_id:
+                self.containers_pod[container_id] = \
+                    (message.namespace, message.pod)
+
+            # logger.debug(
+            #     "Pod modified %s %s , mdt: %s",
+            #     message.namespace, message.pod, message.containers_id
+            # )
+        else:
+            logger.error("Error : unknown event type %s ", message.event)
+
+    def get_container_pod(self, container_id) -> Tuple[str, str]:
+        """
+        Get the pod for a container_id.
+
+        :param container_id
+        :return a tuple (namespace, pod_name) of (None, None) if no pod
+                could be found for this container
+        """
+        ns_pod = self.containers_pod.get(container_id, None)
+        if ns_pod is None:
+            return None, None
+        return ns_pod
+
+    def get_pod_labels(self, namespace: str, pod_name: str) -> Dict[str, str]:
+        """
+        Get labels for a pod.
+
+        :param namespace
+        :param
+        :return a dict {label_name, label_value}
+        """
+        return self.pod_labels.get((namespace, pod_name), dict)
+
+
+class K8sMonitorStartMessage(StartMessage):
+    def __init__(self, sender_name, name, listener_agent, k8sapi_mode):
+        """
+        :param listener_agent the agent `K8sMonitorAgent` must
+                              send it's event to.
+        """
+        StartMessage.__init__(self, sender_name, name)
+        self.listener_agent = listener_agent
+        self.k8sapi_mode = k8sapi_mode
+
+    def __str__(self):
+        return "K8sMonitorStartMessage"
+
+
+class K8sMonitorAgent(Actor):
+    """
+    An actor that monitors the k8s API and sends messages
+    when pod are created, removed or modified.
+    """
+
+    def __init__(self):
+        """
+        :param period: time in second, between to k8s pooling
+        """
+        Actor.__init__(self, K8sMonitorStartMessage)
+        self._time_interval = timedelta(seconds=10)
+        self.timeout_query = 5
+        self.listener_agent = None
+        self.k8sapi_mode = None
+
+    def _initialization(self, start_message: K8sMonitorStartMessage):
+        Actor._initialization(self, start_message)
+        self.listener_agent = start_message.listener_agent
+        self.k8sapi_mode = start_message.k8sapi_mode
+        self.log_warning("setup initial wakeup timer ")
+        self.wakeupAfter(self._time_interval)
+
+    def _query_k8s(self):
+        try:
+            events = k8s_streaming_query(self.timeout_query, self.k8sapi_mode)
+            for event in events:
+                event_type, namespace, pod_name, container_ids, labels = event
+                self.send(
+                    self.listener_agent,
+                    K8sPodUpdateMessage(
+                        self.name,
+                        event_type,
+                        namespace,
+                        pod_name,
+                        container_ids,
+                        labels
+                    )
+                )
+        except Exception as ex:
+            self.log_warning(ex)
+            self.log_warning(f"Failed streaming query {ex}")
+
+    def receiveMsg_WakeupMessage(self, _: WakeupMessage, __: ActorAddress):
+        """
+        When receiving a WakeupMessage, launch the actor task
+        """
+        self.log_debug("Wakeup - K8sMonitorAgent Querying k8s")
+        self._query_k8s()
+        self.log_debug("K8sMonitorAgent Streaming finished, wait until next timer")
+        self.wakeupAfter(self._time_interval)
+
+    def receiveMsg_EndMessage(self, message: EndMessage, _: ActorAddress):
+        """
+        when receiving a EndMessage kill itself
+        """
+        self.log_debug("received message " + str(message))
+        self.send(self.myAddress, ActorExitRequest())
+
+
+def k8s_streaming_query(timeout_seconds, k8sapi_mode):
+    v1_api = get_core_v1_api(k8sapi_mode)
+    events = []
+    w = watch.Watch()
+    # FIXME : handle node name
+    logger.debug(f"Waiting for events on pods with timeout {timeout_seconds}")
+    try:
+        for event in w.stream(
+            v1_api.list_pod_for_all_namespaces, timeout_seconds=timeout_seconds
+        ):
+            if not event["type"] in {"DELETED", "ADDED", "MODIFIED"}:
+                logger.warning(
+                    "UNKNOWN EVENT TYPE : %s :  %s  %s",
+                    event['type'], event['object'].metadata.name, event
+                )
+                continue
+            pod_obj = event["object"]
+            namespace, pod_name = \
+                pod_obj.metadata.namespace, pod_obj.metadata.name
+            container_ids = (
+                [] if event["type"] == "DELETED"
+                else extract_containers(pod_obj)
+            )
+            labels = pod_obj.metadata.labels
+            events.append(
+                (event["type"], namespace, pod_name, container_ids, labels)
+            )
+
+    except ApiException as ae:
+        logger.error(f"APIException {ae.status} {ae}", ae)
+    except Exception as undef_e:
+        logger.error(f"Error when watching Exception '{undef_e}' {event}")
+    return events
+
+
+def extract_containers(pod_obj):
+    # print(pod_obj)
+    if not pod_obj.status.container_statuses:
+        return []
+
+    container_ids = []
+    for container_status in pod_obj.status.container_statuses:
+        container_id = container_status.container_id
+        if not container_id:
+            continue
+        # container_id actually depends on the container engine used by k8s.
+        # It seems that is always start with <something>://<actual_id>
+        # e.g.
+        # 'containerd://2289b494f36b93647cfefc6f6ed4d7f36161d5c2f92d1f23571878a4e85282ed'
+        container_id = container_id[container_id.index("//") + 2:]
+        container_ids.append(container_id)
+
+    return sorted(container_ids)
+
+
+def cleanup_container_id(c_id):
+    # On some system, we receive a container id that requires some cleanup to match
+    # the id returned by the k8s api
+    # k8s creates cgroup directories, which is what we get as id from the sensor,
+    # according to this pattern :
+    #     /kubepods/<qos>/pod<pod-id>/<containerId>
+    # depending on the container engine, we need to cleanup the <containerId> part
+
+    if "/docker-" in c_id:
+        # for path like :
+        # /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod435532e3_546d_45e2_8862_d3c7b320d2d9.slice/docker-68aa4b590997e0e81257ac4a4543d5b278d70b4c279b4615605bb48812c9944a.scope
+        # where we actually only want the end of that path :
+        # 68aa4b590997e0e81257ac4a4543d5b278d70b4c279b4615605bb48812c9944a
+        try:
+            return c_id[c_id.rindex("/docker-") + 8: -6]
+        except ValueError:
+            return c_id
+    else:
+        # /kubepods/besteffort/pod42006d2c-cad7-4575-bfa3-91848a558743/ba28184d18d3fc143d5878c7adbefd7d1651db70ca2787f40385907d3304e7f5
+        try:
+            return c_id[c_id.rindex("/") + 1:]
+        except ValueError:
+            return c_id

--- a/tests/acceptation/test_cloudjoule_exporter.py
+++ b/tests/acceptation/test_cloudjoule_exporter.py
@@ -1,0 +1,75 @@
+# CloudJoule — for powerAPI
+#
+# Copyright (c) 2022 Orange - All right reserved
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from smartwatts.cloudjoule_exporter import (
+    fix_k8s_labels_name,
+    fix_k8s_labels_names,
+)
+
+
+def test_supported_labels_are_not_modified():
+    assert fix_k8s_labels_name("name_ok_15") == "name_ok_15"
+
+
+def test_minus_is_replacedin_k8s_labels():
+    assert fix_k8s_labels_name("name-ko-15") == "name_ko_15"
+
+
+def test_dot_is_replacedin_k8s_labels():
+    assert fix_k8s_labels_name("name.ko-15") == "name_ko_15"
+
+
+def test_slash_is_replacedin_k8s_labels():
+    assert fix_k8s_labels_name("dd/name.ko-15") == "dd_name_ko_15"
+
+
+def test_conflicted_names_are_flagged():
+    given_names = ["foo-bar", "foo_bar"]
+
+    obtained = fix_k8s_labels_names(given_names)
+
+    assert obtained["foo-bar"] == "foo_bar_conflict1"
+    assert obtained["foo_bar"] == "foo_bar_conflict2"
+
+
+def test_nonconflicted_names_are_not_flagged():
+    given_names = ["bar", "foo"]
+
+    obtained = fix_k8s_labels_names(given_names)
+
+    assert obtained["bar"] == "bar"
+    assert obtained["foo"] == "foo"
+
+
+def test_real_names():
+    names = ["pod_name", "pod_namespace", "app", "service", "env", "k8s-app"]
+
+    obtained = fix_k8s_labels_names(names)
+
+    assert obtained["pod_name"] == "pod_name"

--- a/tests/acceptation/test_configuration.py
+++ b/tests/acceptation/test_configuration.py
@@ -1,0 +1,101 @@
+# CloudJoule — for powerAPI
+#
+# Copyright (c) 2022 Orange - All right reserved
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import pytest
+
+
+def test_importing_must_not_fail():
+    from smartwatts import configuration
+
+
+def test_load_config_must_fail_if_missing_mandatory_env():
+    from smartwatts import configuration
+
+    # Make sure ate least one required env variable is not defined
+    os.environ["MIN_FREQ"] = ""
+    with pytest.raises((KeyError, ValueError)):
+        configuration.load_config_from_env()
+
+
+def test_load_must_use_default_value_for_unspecified_nonmandatory_env():
+    from smartwatts import configuration
+
+    # Make sure at least one required env variable is not defined
+    os.environ["MIN_FREQ"] = "10"
+    os.environ["MAX_FREQ"] = "10"
+    os.environ["BASE_FREQ"] = "10"
+    os.environ["SOCKET_COUNT"] = "1"
+    configuration.load_config_from_env()
+
+    assert configuration.REPORT_FREQ == 1000
+
+
+def test_load_set_conf_from_env():
+    from smartwatts import configuration
+
+    os.environ["MIN_FREQ"] = "800"
+    os.environ["MAX_FREQ"] = "2000"
+    os.environ["BASE_FREQ"] = "1000"
+    os.environ["SOCKET_COUNT"] = "1"
+    configuration.load_config_from_env()
+
+    assert configuration.MIN_FREQ == 8
+    assert configuration.MAX_FREQ == 20
+    assert configuration.BASE_FREQ == 10
+    assert configuration.SOCKET_COUNT == 1
+    assert configuration.REPORT_FREQ == 1000
+    assert configuration.ERROR_THRESHOLD == 2
+    assert configuration.MIN_SAMPLES_REQUIRED == 10
+    assert configuration.HISTORY_WINDOW_SIZE == 60
+
+def test_smartwatt_like_conf():
+    from smartwatts import configuration
+    os.environ["MIN_FREQ"] = "10"
+    os.environ["MAX_FREQ"] = "10"
+    os.environ["BASE_FREQ"] = "10"
+    os.environ["SOCKET_COUNT"] = "1"
+    conf = configuration.get_smartwatt_config_map()
+
+    assert conf is not None
+
+def test_label_conf_from_env():
+    from smartwatts import configuration
+    os.environ["MIN_FREQ"] = "10"
+    os.environ["MAX_FREQ"] = "10"
+    os.environ["BASE_FREQ"] = "10"
+    os.environ["SOCKET_COUNT"] = "1"    
+
+    # Default value
+    configuration.load_config_from_env()
+    assert configuration.EXPORTER_LABELS  ==  ["label_app","label_service","label_env"]
+
+    os.environ["EXPORTER_LABELS"] = "label1, label2"    
+    configuration.load_config_from_env()
+    assert configuration.EXPORTER_LABELS  ==  ["label_label1","label_label2"]

--- a/tests/acceptation/test_k8s.py
+++ b/tests/acceptation/test_k8s.py
@@ -1,0 +1,64 @@
+# CloudJoule — for powerAPI
+#
+# Copyright (c) 2022 Orange - All right reserved
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from smartwatts.k8sapi import local_config, k8s_streaming_query, cleanup_container_id
+
+from kubernetes import client
+
+
+def test_load_local_config():
+    # NOTE : this test requires a running k8s cluster !
+    local_config()
+
+    # Just check we are able to make a request and get a non-empty response
+    v1_api = client.CoreV1Api()
+    ret = v1_api.list_pod_for_all_namespaces()
+    assert ret.items != []
+
+
+def test_streaming_query():
+    # NOTE : this test requires a running k8s cluster !
+    
+    def cb(*event):
+        print(event)
+        assert event is not None
+
+    k8s_streaming_query(cb, 10)
+
+def test_cleanupid_docker():
+
+    r = cleanup_container_id("/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod435532e3_546d_45e2_8862_d3c7b320d2d9.slice/docker-68aa4b590997e0e81257ac4a4543d5b278d70b4c279b4615605bb48812c9944a.scope")
+
+    assert r ==  "68aa4b590997e0e81257ac4a4543d5b278d70b4c279b4615605bb48812c9944a"
+
+def test_cleanupid_othercri():
+
+    r = cleanup_container_id("/kubepods/besteffort/pod42006d2c-cad7-4575-bfa3-91848a558743/ba28184d18d3fc143d5878c7adbefd7d1651db70ca2787f40385907d3304e7f5")
+
+    assert r ==  "ba28184d18d3fc143d5878c7adbefd7d1651db70ca2787f40385907d3304e7f5"    


### PR DESCRIPTION
This adds support for Kubernetes to smartwatts. 

Main features
* Support for configuration through environment variables (partial support only, this should be bleanup up and moved to powerAPI instead of smartwatts)
* modifier agent, that monitors K8S and add K8S metatdata to reports (label, namespace, pod name, etc.)
* prometheus exporter with gauge and counter (should be preferred for such metrics with prometheus). This exporter exposes k8s metadata for all monitored pods.

This PR should be used as a basis for discussion, some code should most probably be moved to the PowerAPI repository and more care should be payed to make sure we don't cause any issue when running smartwatts  outside k8s.