### PR TITLE
refactor: Use callable objects instead of nested functions for actors factory

### DIFF
--- a/src/smartwatts/__main__.py
+++ b/src/smartwatts/__main__.py
@@ -45,7 +45,7 @@ from powerapi.filter import Filter
 from powerapi.report import HWPCReport
 
 from smartwatts import __version__ as smartwatts_version
-from smartwatts.actor import SmartWattsFormulaActor, SmartWattsFormulaScope, SmartWattsFormulaConfig
+from smartwatts.actor import SmartWattsFormulaScope, SmartWattsFormulaConfig, SmartWattsFormulaFactory
 from smartwatts.cli import SmartWattsConfigValidator
 from smartwatts.exceptions import InvalidConfigurationParameterException
 from smartwatts.model import CPUTopology
@@ -108,11 +108,9 @@ def setup_cpu_formula_dispatcher(config, route_table, report_filter, cpu_topolog
     :param pushers: Reports pushers
     :return: Initialized CPU dispatcher actor
     """
-    def cpu_formula_factory(name: str, **_):
-        formula_config = generate_formula_configuration(config, cpu_topology, SmartWattsFormulaScope.CPU)
-        return SmartWattsFormulaActor(name, pushers, formula_config)
-
-    cpu_dispatcher = DispatcherActor('cpu_dispatcher', cpu_formula_factory, pushers, route_table)
+    formula_config = generate_formula_configuration(config, cpu_topology, SmartWattsFormulaScope.CPU)
+    formula_factory = SmartWattsFormulaFactory(formula_config)
+    cpu_dispatcher = DispatcherActor('cpu_dispatcher', formula_factory, pushers, route_table)
     report_filter.filter(lambda msg: True, cpu_dispatcher)
     return cpu_dispatcher
 
@@ -127,11 +125,9 @@ def setup_dram_formula_dispatcher(config, route_table, report_filter, cpu_topolo
     :param pushers: Reports pushers
     :return: Initialized DRAM dispatcher actor
     """
-    def dram_formula_factory(name: str, **_):
-        formula_config = generate_formula_configuration(config, cpu_topology, SmartWattsFormulaScope.DRAM)
-        return SmartWattsFormulaActor(name, pushers, formula_config)
-
-    dram_dispatcher = DispatcherActor('dram_dispatcher', dram_formula_factory, pushers, route_table)
+    formula_config = generate_formula_configuration(config, cpu_topology, SmartWattsFormulaScope.DRAM)
+    formula_factory = SmartWattsFormulaFactory(formula_config)
+    dram_dispatcher = DispatcherActor('dram_dispatcher', formula_factory, pushers, route_table)
     report_filter.filter(lambda msg: True, dram_dispatcher)
     return dram_dispatcher
 

--- a/src/smartwatts/actor/factory.py
+++ b/src/smartwatts/actor/factory.py
@@ -36,6 +36,9 @@ from .config import SmartWattsFormulaConfig
 
 
 class SmartWattsFormulaFactory:
+    """
+    Factory to create SmartWatts formula actors.
+    """
 
     def __init__(self, actor_config: SmartWattsFormulaConfig):
         """

--- a/src/smartwatts/actor/factory.py
+++ b/src/smartwatts/actor/factory.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2022, INRIA
-# Copyright (c) 2022, University of Lille
+# Copyright (c) 2023, INRIA
+# Copyright (c) 2023, University of Lille
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,14 +27,27 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .actor import SmartWattsFormulaActor, SmartWattsFormulaState
-from .config import SmartWattsFormulaConfig, SmartWattsFormulaScope
-from .factory import SmartWattsFormulaFactory
+from typing import Dict
 
-__all__ = [
-    'SmartWattsFormulaActor',
-    'SmartWattsFormulaState',
-    'SmartWattsFormulaConfig',
-    'SmartWattsFormulaScope',
-    'SmartWattsFormulaFactory'
-]
+from powerapi.pusher import PusherActor
+
+from .actor import SmartWattsFormulaActor
+from .config import SmartWattsFormulaConfig
+
+
+class SmartWattsFormulaFactory:
+
+    def __init__(self, actor_config: SmartWattsFormulaConfig):
+        """
+        Initialize a new SmartWatts formula factory.
+        """
+        self.actor_config = actor_config
+
+    def __call__(self, actor_name: str, pushers: Dict[str, PusherActor]) -> SmartWattsFormulaActor:
+        """
+        Create a new SmartWatts formula actor.
+        :param actor_name: Name of the actor
+        :param pushers: Dictionary of available pushers
+        :return: A new SmartWatts formula actor
+        """
+        return SmartWattsFormulaActor(actor_name, pushers, self.actor_config)


### PR DESCRIPTION
This is preliminary work for the support of python multiprocessing `spawn` start method.