### PR TITLE
build(Dockerfile): Use PowerAPI global virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/powerapi/powerapi:2.8.0@sha256:d1a3946c07e21971299fc9ea0d2b8313652d4865f6d3a044e7873716aa96430f
 
-USER powerapi
 COPY --chown=powerapi . /tmp/smartwatts
-RUN pip install --user --no-cache-dir "/tmp/smartwatts" && rm -r /tmp/smartwatts
+RUN pip install --no-cache-dir "/tmp/smartwatts" && rm -r /tmp/smartwatts
 
+USER powerapi
 ENTRYPOINT ["python3", "-m", "smartwatts"]


### PR DESCRIPTION
Using a user virtualenv prevents the container from being run as another user with the `--user` docker/podman run flag.
Since PowerAPI v2.8.0, a global virtualenv available in the image, which fixes this problem.

This is useful to run SmartWatts with a rootless container runtime and have the output files with the same permissions as the running user.