### PR TITLE
Bugfix for typo introduced on commit `e5b0c40`

### DIFF
--- a/src/smartwatts/handler/hwpc_report.py
+++ b/src/smartwatts/handler/hwpc_report.py
@@ -245,7 +245,7 @@ class HwPCReportHandler(Handler):
         :return: A dictionary containing an aggregate of the Core events for the running targets of the current socket
         """
         agg_core_events_group = defaultdict(int)
-        for target_report in targets_report.value():
+        for target_report in targets_report.values():
             for event_name, event_value in self._gen_core_events_group(target_report).items():
                 agg_core_events_group[event_name] += event_value
 


### PR DESCRIPTION
Commit [`e5b0c40`](https://github.com/powerapi-ng/smartwatts-formula/commit/e5b0c40d0d1896bd0e55fa55f86b78bb8c6931ba) changed line:
```python
for _, target_report in targets_report.items():
```
With:
```python
for target_report in targets_report.value():
```
On line 235 in file `src/smartwatts/handler/hwpc_report.py`.
The call to `.value()` should have been `.values()`, causing a crash. This merge request fixes it.